### PR TITLE
Make decorator compatible with the `doctest` module

### DIFF
--- a/src/barriers/barriers.py
+++ b/src/barriers/barriers.py
@@ -545,5 +545,10 @@ class barriers: # pylint: disable=too-few-public-methods
         """
         return self._transform(function, self._namespace)
 
+    def __getattr__(self, attr):
+        if attr == '__wrapped__':
+            raise AttributeError
+        return self.__getattribute__(attr)
+
 if __name__ == '__main__':
     doctest.testmod() # pragma: no cover


### PR DESCRIPTION
The pull request resolves this issue: https://bugs.python.org/issue35753

Without this change, the following error occurs:
```python
$ python rbcl/rbcl.py
Traceback (most recent call last):
  File "./rbcl/rbcl.py", line 749, in <module>
    doctest.testmod()  # pragma: no cover
  File ".../doctest.py", line 1953, in testmod
    for test in finder.find(m, name, globs=globs, extraglobs=extraglobs):
  File ".../doctest.py", line 939, in find
    self._find(tests, obj, name, module, source_lines, globs, {})
  File ".../doctest.py", line 998, in _find
    if ((inspect.isroutine(inspect.unwrap(val))
  File "./inspect.py", line 525, in unwrap
    raise ValueError('wrapper loop when unwrapping {!r}'.format(f))
ValueError: wrapper loop when unwrapping <barriers.barriers.barriers object at 0x1017c8670>
```

See https://github.com/nthparty/rbcl/commit/93d0e3 for the specific context of this issue.

The `doctest` module will call the `__wrapped__` method of the barriers object repeatedly, and because this is equal to the object itself when the object is a decorator, there is an infinite loop.
